### PR TITLE
Move `summary` in Story to `content` in top-level section

### DIFF
--- a/loom/database/clients/mongodb_clients.py
+++ b/loom/database/clients/mongodb_clients.py
@@ -299,7 +299,6 @@ class MongoDBClient:
                            title: str,
                            wiki_id: ObjectId,
                            user_description,  # TODO: Decide what this is.
-                           summary: str,
                            section_id: ObjectId,
                            _id=None) -> ObjectId:
         # TODO: Implement statistics and settings.
@@ -307,7 +306,6 @@ class MongoDBClient:
             'title':      title,
             'wiki_id':    wiki_id,
             'users':      [user_description],
-            'summary':    summary,
             'section_id': section_id,
             'statistics': None,
             'settings':   None,

--- a/loom/database/interfaces/mongodb_interfaces.py
+++ b/loom/database/interfaces/mongodb_interfaces.py
@@ -166,7 +166,8 @@ class MongoDBInterface(AbstractDBInterface):
             'access_level': 'owner',
         }
         section_id = await self.create_section(title)
-        inserted_id = await self.client.create_story(title, wiki_id, user_description, summary, section_id)
+        await self.add_paragraph(section_id, summary)
+        inserted_id = await self.client.create_story(title, wiki_id, user_description, section_id)
         await self.client.add_story_to_user(user_id, inserted_id)
         return inserted_id
 

--- a/loom/dispatchers/LAWProtocolDispatcher.py
+++ b/loom/dispatchers/LAWProtocolDispatcher.py
@@ -174,7 +174,6 @@ class LAWProtocolDispatcher:
             'section_id':   story['section_id'],
             'wiki_id':      story['wiki_id'],
             'users':        story['users'],
-            'summary':      story['summary'],
         }
         return CreateStoryOutgoingMessage(message_id, **message)
 
@@ -229,7 +228,6 @@ class LAWProtocolDispatcher:
             'section_id':   story['section_id'],
             'wiki_id':      story['wiki_id'],
             'users':        story['users'],
-            'summary':      story['summary'],
         }
         return GetStoryInformationOutgoingMessage(message_id, **message)
 

--- a/loom/dispatchers/messages/outgoing/story_messages.py
+++ b/loom/dispatchers/messages/outgoing/story_messages.py
@@ -10,14 +10,13 @@ from bson import ObjectId
 ###########################################################################
 class CreateStoryOutgoingMessage(OutgoingMessage):
     def __init__(self, reply_to_id: int, story_title: str, story_id: ObjectId, section_id: ObjectId, wiki_id: ObjectId,
-                 users: list, summary: str):
+                 users: list):
         self.reply_to_id = reply_to_id
         self.story_title = story_title
         self.story_id = story_id
         self.section_id = section_id
         self.wiki_id = wiki_id
         self.users = users
-        self.summary = summary
 
 
 ###########################################################################
@@ -75,14 +74,12 @@ class EditSectionTitleOutgoingMessage(OutgoingMessage):
 #
 ###########################################################################
 class GetStoryInformationOutgoingMessage(OutgoingMessage):
-    def __init__(self, reply_to_id: int, story_title: str, section_id: ObjectId, wiki_id: ObjectId, users: list,
-                 summary: str):
+    def __init__(self, reply_to_id: int, story_title: str, section_id: ObjectId, wiki_id: ObjectId, users: list):
         self.reply_to_id = reply_to_id
         self.story_title = story_title
         self.section_id = section_id
         self.wiki_id = wiki_id
         self.users = users
-        self.summary = summary
 
 
 class GetStoryHierarchyOutgoingMessage(OutgoingMessage):

--- a/tests/test_db_interface.py
+++ b/tests/test_db_interface.py
@@ -112,7 +112,6 @@ class TestDBInterface:
         assert story_summary in story_ids
         db_story = await self.interface.get_story(story_id)
         assert db_story['title'] == story['title']
-        assert db_story['summary'] == story['summary']
         assert db_story['wiki_id'] == story['wiki_id']
         user_description = {
             'user_id': user_id,

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -198,7 +198,6 @@ class TestLAWDispatcher:
             'access_level': 'owner',
         }
         assert user_info in result.users
-        assert result.summary == msg['summary']
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('action, msg', [
@@ -340,7 +339,6 @@ class TestLAWDispatcher:
             'access_level':  'owner',
         }
         assert user_info in result.users
-        assert result.summary == TEST_STORY['summary']
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('action, msg', [
@@ -384,7 +382,10 @@ class TestLAWDispatcher:
         result = await self.dispatcher.dispatch(msg, action)
         assert isinstance(result, GetSectionContentOutgoingMessage)
         assert result.reply_to_id == msg['message_id']
-        assert result.content == list()
+        assert isinstance(result.content, list)
+        assert isinstance(result.content[0], dict)
+        assert isinstance(result.content[0]['paragraph_id'], ObjectId)
+        assert result.content[0]['text'] == TEST_STORY['summary']
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('action, msg', [


### PR DESCRIPTION
Removed `summary` field from story altogether.